### PR TITLE
fixed panic string literal warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ mod tests {
             // Finish the compression stream.
             let result = BZ2_bzCompressEnd(&mut stream as *mut _);
             match result {
-                r if r == (BZ_PARAM_ERROR as _) => panic!(BZ_PARAM_ERROR),
+                r if r == (BZ_PARAM_ERROR as _) => panic!("BZ_PARAM_ERROR"),
                 r if r == (BZ_OK as _) => {},
                 r => panic!("Unknown return value = {}", r),
             }


### PR DESCRIPTION
New `panic!()` wants a string literal for a first argument. This fixes that.